### PR TITLE
charset error fix and relative url path fix (parcel)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
 <!doctype>
 <html>
 <head>
+  <meta charset="utf-8"/>
   <title>Hello Concur!</title>
 </head>
 <body>
   <div id="root"></div>
-  <script src="index.js"></script>
+  <script type="application/javascript" src="index.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf .cache .spago .psci_modules output .pulp-cache prod dist",
     "build": "spago build",
-    "dev": "rimraf dist && spago install && spago build && parcel build index.html",
-    "prod": "rimraf prod dist && mkdir prod && spago bundle --main Main --to prod/index.prod.js && java -jar closure-compiler/closure-compiler-v20190301.jar --js prod/index.prod.js --js_output_file prod/index.js && cp index.html prod/index.html && parcel build prod/index.html && rimraf prod",
-    "start": "spago build && parcel index.html",
+    "dev": "rimraf dist && spago install && spago build && parcel --public-url ./ build index.html",
+    "prod": "rimraf prod dist && mkdir prod && spago bundle --main Main --to prod/index.prod.js && java -jar closure-compiler/closure-compiler-v20190301.jar --js prod/index.prod.js --js_output_file prod/index.js && cp index.html prod/index.html && parcel --public-url ./ build prod/index.html && rimraf prod",
+    "start": "spago build && parcel --public-url ./ index.html",
     "watch": "spago build && parcel watch index.html"
   },
   "author": "Anupam Jain <ajnsit@gmail.com> (https://github.com/ajnsit)",


### PR DESCRIPTION
The first fix adds

```html
<meta charset="utf-8"/>
```

Otherwise firefox reports an error:

>The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol. index.html

The second and likely more significant fix is `--public-url ./ `is so that the relative url is relative to the current directory, otherwise parcel generates e.g. ` <script src="/wd.e31bb0bc.js"></script>`